### PR TITLE
[#6] Updated setup.py to create an entry points line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .idea
-Pipfile.lock
 .venv
 build
 dist
 *.spec
 standup_notes/__pycache__
 standup_notes.egg-info
+.vscode

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ python-editor = "==1.0.4"
 pyperclip = "==1.8.0"
 
 [dev-packages]
+pylint = "*"
 
 [requires]
 python_version = "3.7"
-

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ python-editor = "==1.0.4"
 pyperclip = "==1.8.0"
 
 [dev-packages]
-pylint = "*"
+pylint = "==1.9.5"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,147 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b85c8e6e768ac040723ed83574008dd89bf1c4ad4c57a2e1364e77e4e1f7f638"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pyperclip": {
+            "hashes": [
+                "sha256:b75b975160428d84608c26edba2dec146e7799566aea42c1fe1b32e72b6028f2"
+            ],
+            "index": "pypi",
+            "version": "==1.8.0"
+        },
+        "python-editor": {
+            "hashes": [
+                "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
+                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
+                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"
+            ],
+            "index": "pypi",
+            "version": "==1.0.4"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:87de48a92e29cedf7210ffa853d11441e7ad94cb47bacd91b023499b51cbc756",
+                "sha256:d25869fc7f44f1d9fb7d24fd7ea0639656f5355fc3089cd1f3d18c6ec6b124c7"
+            ],
+            "version": "==1.6.6"
+        },
+        "backports.functools-lru-cache": {
+            "hashes": [
+                "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848",
+                "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==1.6.1"
+        },
+        "configparser": {
+            "hashes": [
+                "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c",
+                "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==4.0.2"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53",
+                "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328",
+                "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.10"
+        },
+        "futures": {
+            "hashes": [
+                "sha256:49b3f5b064b6e3afc3316421a3f25f66c137ae88f068abbf72830170033c5e16",
+                "sha256:7e033af76a5e35f58e56da7a91e687706faf4e7bdfb2cbc3f2cca6b9bcda9794"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.3.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
+                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+            ],
+            "version": "==4.3.21"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+            ],
+            "version": "==1.4.3"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:367e3d49813d349a905390ac27989eff82ab84958731c5ef0bef867452cfdc42",
+                "sha256:97a42df23d436c70132971d1dcb9efad2fe5c0c6add55b90161e773caf729300"
+            ],
+            "index": "pypi",
+            "version": "==1.9.5"
+        },
+        "singledispatch": {
+            "hashes": [
+                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
+                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==3.4.0.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+            ],
+            "version": "==1.12.1"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 ## Configure
 ```
+### From source code
 sudo python3 -m pip install pipenv 
-alias standup-notes=<workspace>/standup_notes/bin/standup-notes
+python setup.py install
+
+### From PyPi
+TODO instructions on pip installing from PyPi
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ```
 ### From source code
 sudo python3 -m pip install pipenv 
-sudo python3 setup.py install
+sudo python3 setup.py install --user
 
 ### From PyPi
 TODO instructions on pip installing from PyPi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ```
 ### From source code
 sudo python3 -m pip install pipenv 
-python setup.py install
+sudo python3 setup.py install
 
 ### From PyPi
 TODO instructions on pip installing from PyPi

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ sudo python3 -m pip install pipenv
 sudo python3 setup.py install --user
 
 ### From PyPi
-TODO instructions on pip installing from PyPi
+sudo pip3 install standup-notes
 ```
 
 ## Run

--- a/bin/standup-notes
+++ b/bin/standup-notes
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cd $(dirname $0)/../
-pipenv run python3 -m standup_notes "$@"

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url="http://www.mikemartino.ca",
     packages=find_packages(),
+    install_requires=['python-editor==1.0.4', 'pyperclip==1.8.0'],
     entry_points={
           'console_scripts': [
               'standup-notes = standup_notes.__main__:main'

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-import setuptools
+from setuptools import setup, find_packages
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(
+setup(
     name="standup-notes", 
     version="0.0.1",
     author="Mike Martino",
@@ -12,7 +12,15 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="http://www.mikemartino.ca",
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
+    entry_points={
+          'console_scripts': [
+              'standup-notes = standup_notes.__main__:main'
+          ]
+      },
+    package_data={
+        "standup_notes": ["resources/*.template"],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/standup_notes/__main__.py
+++ b/standup_notes/__main__.py
@@ -11,7 +11,22 @@ EXT = '.standup-notes.txt'
 STANDUP_NOTES = os.path.join(os.environ.get("HOME"), 'Desktop/standup-notes')
 STANDUP_TEMPLATE = resource_stream('standup_notes.resources', 'standup.template')
 
-def main(arguments: Namespace):
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('--list', help='List all stand-up notes.', action='store_true')
+    parser.add_argument('--read-today', help='Read today\'s stand-up notes.', action='store_true')
+    parser.add_argument('--read-tomorrow', help='Read tomorrow\'s stand-up notes.', action='store_true')
+    parser.add_argument('--copy-today', help='Copy today\'s stand-up notes to the clipboard.', action='store_true')
+    parser.add_argument('--copy-tomorrow', help='Copy tomorrow\'s stand-up notes to the clipboard.', action='store_true')
+    parser.add_argument('--edit-today', help='Edit today\'s stand-up notes.', action='store_true')
+    parser.add_argument('--edit-tomorrow', help='Edit tomorrow\'s stand-up notes.', action='store_true')
+    args = parser.parse_args()
+
+    # sys.argv includes a list of elements starting with the program name
+    if len(sys.argv) < 2:
+        parser.print_usage()
+        sys.exit(1)
+
     today = date.strftime(date.today(), '%Y%m%d')
     today_note = os.path.join(STANDUP_NOTES, today + EXT)
     tomorrow = date.strftime(next_weekday(date.today()), '%Y%m%d')
@@ -82,20 +97,5 @@ def next_weekday(day: date) -> date:
 
 
 if __name__ == '__main__':
-    parser = ArgumentParser()
-    parser.add_argument('--list', help='List all stand-up notes.', action='store_true')
-    parser.add_argument('--read-today', help='Read today\'s stand-up notes.', action='store_true')
-    parser.add_argument('--read-tomorrow', help='Read tomorrow\'s stand-up notes.', action='store_true')
-    parser.add_argument('--copy-today', help='Copy today\'s stand-up notes to the clipboard.', action='store_true')
-    parser.add_argument('--copy-tomorrow', help='Copy tomorrow\'s stand-up notes to the clipboard.', action='store_true')
-    parser.add_argument('--edit-today', help='Edit today\'s stand-up notes.', action='store_true')
-    parser.add_argument('--edit-tomorrow', help='Edit tomorrow\'s stand-up notes.', action='store_true')
-    args = parser.parse_args()
-
-    # sys.argv includes a list of elements starting with the program name
-    if len(sys.argv) < 2:
-        parser.print_usage()
-        sys.exit(1)
-    
-    main(args)
+    main()
 

--- a/standup_notes/__main__.py
+++ b/standup_notes/__main__.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument('--copy-tomorrow', help='Copy tomorrow\'s stand-up notes to the clipboard.', action='store_true')
     parser.add_argument('--edit-today', help='Edit today\'s stand-up notes.', action='store_true')
     parser.add_argument('--edit-tomorrow', help='Edit tomorrow\'s stand-up notes.', action='store_true')
-    args = parser.parse_args()
+    arguments = parser.parse_args()
 
     # sys.argv includes a list of elements starting with the program name
     if len(sys.argv) < 2:


### PR DESCRIPTION
This removes the requirement to have a script in the bin folder. With this change, you can call the standup_notes package directly as a command line script after installing it using "python setup.py install". Once these changes are approved, I'll actually release to it PyPi and add instructions in the README on how to install it from there.