### PR TITLE
- fixed bash script to included copy flag and reduce other inputs

### DIFF
--- a/standup_notes/__main__.py
+++ b/standup_notes/__main__.py
@@ -28,7 +28,6 @@ def main():
                                              'Otherwise, copies the specified day\'s notes ', action='store_true')
     parser.add_argument('-e', '--edit', help='Edit stand-up notes', action='store_true')
     parser.add_argument('-d', '--delete', help='Delete stand-up notes from inputted date', action='store', type=str)
-    parser.add_argument('-p', '--post', help="Post specified days chats to mattermost", action='store_true')
     arguments = parser.parse_args()
 
     # sys.argv includes a list of elements starting with the program name

--- a/standup_notes/resources/standup-notes.bash
+++ b/standup_notes/resources/standup-notes.bash
@@ -2,36 +2,32 @@
 
 _standup_completions()
 {
-    local cur prev opts
+    local cur prev opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    first_arg="${COMP_WORDS[1]}"
+    prev2="${COMP_WORDS[COMP_CWORD-2]}"
 
-    opts="-l --list -v --view -c --copy -e --edit -d --delete"
+    opts="-l --list -r --read -c --copy -e --edit -d --delete"
     days="--today --tomorrow --yesterday"
 
     case "${prev}" in
       -l | --list | -d | --delete | --today | --tomorrow | --yesterday)
-        case "${first_arg}" in
-          -e | --edit)
-          COMPREPLY=($(compgen -W "-c --copy" -- ${cur}))
-          return 0
-          ;;
-        esac
+        if [ "$prev2" = "-e" ] || [ "$prev2" = "--edit" ]; then
+          COMPREPLY=( $(compgen -W "-c --copy" -- ${cur}))
+        fi
         return 0
         ;;
-      -c | --copy| -e | --edit | -v | --view)
-      if [ "${#COMP_WORDS[@]}" != "3" ]; then
-        return
-      fi
+      -c | --copy | -e | --edit | -r | --read)
+        if [ "$prev2" = "--yesterday" ] || [ "$prev2" = "--today" ] ||[ "$prev2" = "--tomorrow" ] ; then
+          return 0
+        fi
         COMPREPLY=( $(compgen -W "${days}" -- ${cur}))
         return 0
         ;;
       *)
       ;;
     esac
-
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}))
 
 

--- a/standup_notes/resources/standup-notes.bash
+++ b/standup_notes/resources/standup-notes.bash
@@ -2,7 +2,7 @@
 
 _standup_completions()
 {
-    local cur prev opts prev prev2
+    local cur opts prev prev2
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/standup_notes/resources/standup-notes.bash
+++ b/standup_notes/resources/standup-notes.bash
@@ -2,7 +2,7 @@
 
 _standup_completions()
 {
-    local cur prev opts
+    local cur prev opts prev prev2
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/standup_notes/resources/standup-notes.bash
+++ b/standup_notes/resources/standup-notes.bash
@@ -2,7 +2,7 @@
 
 _standup_completions()
 {
-    local cur prev opts base
+    local cur prev opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"


### PR DESCRIPTION
closes #27 
The previous version did not prompt the user for the copy flag if they wanted it. 